### PR TITLE
fix: FanSync should use max(CPU, GPU) target RPM, not CPU-only

### DIFF
--- a/Services/TrayService.cs
+++ b/Services/TrayService.cs
@@ -500,10 +500,24 @@ namespace OmenSuperHub.Services {
         int fanSpeed1, fanSpeed2;
         if (ConfigService.FanControl == "smart" || ConfigService.FanControl == "custom") {
           fanSpeed1 = FanService.GetSmartFanSpeed(0) / 100;
-          fanSpeed2 = ConfigService.FanSync ? fanSpeed1 : FanService.GetSmartFanSpeed(1) / 100;
+          int gpuTargetSmart = FanService.GetSmartFanSpeed(1) / 100;
+          if (ConfigService.FanSync) {
+            int syncSpeed = System.Math.Max(fanSpeed1, gpuTargetSmart);
+            fanSpeed1 = syncSpeed;
+            fanSpeed2 = syncSpeed;
+          } else {
+            fanSpeed2 = gpuTargetSmart;
+          }
         } else {
           fanSpeed1 = FanService.GetFanSpeedForTemperature(0) / 100;
-          fanSpeed2 = ConfigService.FanSync ? fanSpeed1 : FanService.GetFanSpeedForTemperature(1) / 100;
+          int gpuTargetAuto = FanService.GetFanSpeedForTemperature(1) / 100;
+          if (ConfigService.FanSync) {
+            int syncSpeed = System.Math.Max(fanSpeed1, gpuTargetAuto);
+            fanSpeed1 = syncSpeed;
+            fanSpeed2 = syncSpeed;
+          } else {
+            fanSpeed2 = gpuTargetAuto;
+          }
         }
         // ponytail: AMD EC 需要每 tick 保活，否则 ~3 秒后回退到 BIOS 风扇表。
         // SetMaxFanSpeedOff(0x27) 通知 EC "保持在软件控制模式"，


### PR DESCRIPTION
## Problem

When `FanSync` is enabled, GPU fan was directly using CPU fan's target speed (`fanSpeed1`) without considering GPU temperature.

This causes insufficient cooling under high GPU load — e.g. GPU at 82°C but fans only spinning at 3300 RPM because CPU was cool, when the GPU curve says 4500 RPM.

## Fix

| FanSync | Behavior |
|----------|----------|
| **ON**  | `syncSpeed = Math.Max(CPU target, GPU target)` → both fans use the higher value |
| **OFF** | CPU/GPU each use their own target (unchanged) |

### Changes in `Services/TrayService.cs` — `StartTimers()` `fanControlTimer` callback

**Before:**
```csharp
fanSpeed2 = ConfigService.FanSync ? fanSpeed1 : FanService.GetSmartFanSpeed(1) / 100;
// ...
fanSpeed2 = ConfigService.FanSync ? fanSpeed1 : FanService.GetFanSpeedForTemperature(1) / 100;
```

**After:**
```csharp
int gpuTargetSmart = FanService.GetSmartFanSpeed(1) / 100;
if (ConfigService.FanSync) {
    int syncSpeed = System.Math.Max(fanSpeed1, gpuTargetSmart);
    fanSpeed1 = syncSpeed;
    fanSpeed2 = syncSpeed;
} else {
    fanSpeed2 = gpuTargetSmart;
}
```

Same pattern for the auto/non-smart branch.

Fixes #21